### PR TITLE
Fix signifiers getting wrapped twice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,10 @@ export default class BuJoPlugin extends Plugin {
     this.commandHandler = new CommandHandler(this);
 
     this.registerMarkdownPostProcessor((element, _context) => {
-      const renderedNotes = element.findAll('ul > li')
-      const renderedCheckboxes = element.findAll('.task-list-item')
-      const renderedBullets = [...renderedNotes, ...renderedCheckboxes]
+      const renderedBullets = element.findAll('ul > li');
+      const renderedCheckboxes = renderedBullets.filter((bullet) =>
+        bullet.classList.contains('task-list-item')
+      );
 
       if (renderedBullets.length === 0) {
         return


### PR DESCRIPTION
See #3 for details.

Basically, the `.task-list-item` selector will select HTML elements that were already selected by `ul > li`.
Combining them both into `renderedBullets` duplicated checkbox items.

In my changes, I query the DOM only once for all `ul > li` items, then use filtering to find inside these items the ones that are actually checkboxes.
